### PR TITLE
Add statusPagamento to Pedido entity and update related components

### DIFF
--- a/src/main/java/br/com/fiap/soat8/grp14/techchallenge/app/dto/pedido/PedidoStatusPagamentoDTO.java
+++ b/src/main/java/br/com/fiap/soat8/grp14/techchallenge/app/dto/pedido/PedidoStatusPagamentoDTO.java
@@ -1,0 +1,22 @@
+package br.com.fiap.soat8.grp14.techchallenge.app.dto.pedido;
+
+import br.com.fiap.soat8.grp14.techchallenge.core.entities.enums.StatusPagamento;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PedidoStatusPagamentoDTO {
+
+    @NotNull
+    private Long pedidoId;
+
+    @NotNull
+    private StatusPagamento statusPagamento;
+
+}

--- a/src/main/java/br/com/fiap/soat8/grp14/techchallenge/app/services/PedidoService.java
+++ b/src/main/java/br/com/fiap/soat8/grp14/techchallenge/app/services/PedidoService.java
@@ -3,6 +3,7 @@ package br.com.fiap.soat8.grp14.techchallenge.app.services;
 import br.com.fiap.soat8.grp14.techchallenge.app.dto.pedido.PedidoAtualizarStatusDTO;
 import br.com.fiap.soat8.grp14.techchallenge.app.dto.pedido.PedidoDTO;
 import br.com.fiap.soat8.grp14.techchallenge.app.dto.pedido.PedidoInsertDTO;
+import br.com.fiap.soat8.grp14.techchallenge.app.dto.pedido.PedidoStatusPagamentoDTO;
 import br.com.fiap.soat8.grp14.techchallenge.core.entities.Pedido;
 import br.com.fiap.soat8.grp14.techchallenge.core.usecases.pedido.*;
 import br.com.fiap.soat8.grp14.techchallenge.data.models.ClienteEntity;
@@ -24,6 +25,7 @@ public class PedidoService {
     private final BuscarPedidoUseCase buscarPedidoUseCase;
     private final AtualizarStatusPedidoUseCase atualizarStatusPedidoUseCase;
     private final ListarPedidoOrdenadoUseCase listarPedidoOrdenadoUseCase;
+    private final AtualizarStatusPagamentoUseCase atualizarStatusPagamentoUseCase;
 
     private final ModelMapper mapper;
 
@@ -69,5 +71,9 @@ public class PedidoService {
 
     public List<PedidoDTO> listarPedidosOrdenado() {
         return this.listarPedidoOrdenadoUseCase.execute(true).stream().map(pedido -> mapper.map(pedido, PedidoDTO.class)).toList();
+    }
+
+    public PedidoDTO atualizarStatusPagamento(PedidoStatusPagamentoDTO pedidoStatusPagamentoDTO) {
+        return mapper.map(this.atualizarStatusPagamentoUseCase.execute(pedidoStatusPagamentoDTO), PedidoDTO.class);
     }
 }

--- a/src/main/java/br/com/fiap/soat8/grp14/techchallenge/core/entities/Pedido.java
+++ b/src/main/java/br/com/fiap/soat8/grp14/techchallenge/core/entities/Pedido.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import br.com.fiap.soat8.grp14.techchallenge.core.entities.enums.StatusPagamento;
 import br.com.fiap.soat8.grp14.techchallenge.core.entities.enums.StatusPedido;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -25,5 +26,6 @@ public class Pedido {
     private StatusPedido statusPedido;
     private Cliente cliente;
     private List<ItemPedido> itens = new ArrayList<>();
+    private StatusPagamento statusPagamento;
 
 }

--- a/src/main/java/br/com/fiap/soat8/grp14/techchallenge/core/entities/enums/StatusPagamento.java
+++ b/src/main/java/br/com/fiap/soat8/grp14/techchallenge/core/entities/enums/StatusPagamento.java
@@ -1,0 +1,17 @@
+package br.com.fiap.soat8.grp14.techchallenge.core.entities.enums;
+
+public enum StatusPagamento {
+    EM_APROVACAO("Em aprovação", "Agurando a aprovação do pagamento"),
+    APROVADO("Aprovado", "Pagamento aprovado."),
+    REJEITADO("Rejeitado", "A forma de pagamento selecionanda foi rejeitada"),
+    CANCELADO("Cancelado", "O pagamento foi cancelado pelo cliente");
+
+    private final String nome;
+    private final String descricao;
+
+    StatusPagamento(String nome, String descricao) {
+        this.nome = nome;
+        this.descricao = descricao;
+    }
+
+}

--- a/src/main/java/br/com/fiap/soat8/grp14/techchallenge/core/usecases/pedido/AtualizarStatusPagamentoUseCase.java
+++ b/src/main/java/br/com/fiap/soat8/grp14/techchallenge/core/usecases/pedido/AtualizarStatusPagamentoUseCase.java
@@ -1,0 +1,30 @@
+package br.com.fiap.soat8.grp14.techchallenge.core.usecases.pedido;
+
+import br.com.fiap.soat8.grp14.techchallenge.app.dto.pedido.PedidoStatusPagamentoDTO;
+import br.com.fiap.soat8.grp14.techchallenge.app.exceptions.EntityNotFoundException;
+import br.com.fiap.soat8.grp14.techchallenge.core.entities.Pedido;
+import br.com.fiap.soat8.grp14.techchallenge.core.interfaces.AbstractUseCase;
+import br.com.fiap.soat8.grp14.techchallenge.data.models.PedidoEntity;
+import br.com.fiap.soat8.grp14.techchallenge.data.repositories.PedidoRepository;
+
+public class AtualizarStatusPagamentoUseCase extends AbstractUseCase<PedidoStatusPagamentoDTO, Pedido> {
+
+    private static final String PEDIDO_NAO_ENCONTRADO = "Pedido não encontrado";
+
+    private final PedidoRepository pedidoRepository;
+
+    public AtualizarStatusPagamentoUseCase(PedidoRepository pedidoRepository) {
+        this.pedidoRepository = pedidoRepository;
+    }
+
+    @Override
+    public Pedido execute(PedidoStatusPagamentoDTO pedidoStatusPagamentoDTO) {
+        PedidoEntity pedidoEntity = pedidoRepository.findById(pedidoStatusPagamentoDTO.getPedidoId())
+                .orElseThrow(() -> new EntityNotFoundException(PEDIDO_NAO_ENCONTRADO));
+
+        pedidoEntity.setStatusPagamento(pedidoStatusPagamentoDTO.getStatusPagamento());
+
+        return getModelMapper().map(this.pedidoRepository.save(pedidoEntity), Pedido.class);
+    }
+}
+

--- a/src/main/java/br/com/fiap/soat8/grp14/techchallenge/data/models/PedidoEntity.java
+++ b/src/main/java/br/com/fiap/soat8/grp14/techchallenge/data/models/PedidoEntity.java
@@ -4,6 +4,7 @@ import java.io.Serial;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import br.com.fiap.soat8.grp14.techchallenge.core.entities.enums.StatusPagamento;
 import br.com.fiap.soat8.grp14.techchallenge.core.entities.enums.StatusPedido;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Max;
@@ -54,6 +55,9 @@ public class PedidoEntity extends BaseEntity {
     @OneToMany(mappedBy = "pedido", cascade = CascadeType.ALL, orphanRemoval = true)
     @ToString.Exclude
     private List<ItemPedidoEntity> itens;
+
+    @Column(name = "status_pagamento")
+    private StatusPagamento statusPagamento;
 
     @PrePersist
     protected void onCreate() {

--- a/src/main/java/br/com/fiap/soat8/grp14/techchallenge/infra/config/beans/PedidoUseCaseBeans.java
+++ b/src/main/java/br/com/fiap/soat8/grp14/techchallenge/infra/config/beans/PedidoUseCaseBeans.java
@@ -33,4 +33,10 @@ public class PedidoUseCaseBeans {
     public ListarPedidoOrdenadoUseCase listarPedidoOrdenadoUseCase(PedidoRepository pedidoRepository) {
         return new ListarPedidoOrdenadoUseCase(pedidoRepository);
     }
+
+    @Bean
+    public AtualizarStatusPagamentoUseCase atualizarStatusPagamentoUseCase(PedidoRepository pedidoRepository) {
+        return new AtualizarStatusPagamentoUseCase(pedidoRepository);
+    }
+
 }

--- a/src/main/java/br/com/fiap/soat8/grp14/techchallenge/presentation/controllers/PedidoController.java
+++ b/src/main/java/br/com/fiap/soat8/grp14/techchallenge/presentation/controllers/PedidoController.java
@@ -3,6 +3,7 @@ package br.com.fiap.soat8.grp14.techchallenge.presentation.controllers;
 import br.com.fiap.soat8.grp14.techchallenge.app.dto.pedido.PedidoAtualizarStatusDTO;
 import br.com.fiap.soat8.grp14.techchallenge.app.dto.pedido.PedidoDTO;
 import br.com.fiap.soat8.grp14.techchallenge.app.dto.pedido.PedidoInsertDTO;
+import br.com.fiap.soat8.grp14.techchallenge.app.dto.pedido.PedidoStatusPagamentoDTO;
 import br.com.fiap.soat8.grp14.techchallenge.app.services.PedidoService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -57,6 +58,13 @@ public class PedidoController {
     public ResponseEntity<List<PedidoDTO>> listaPedidoOrdenado() {
         return ResponseEntity.ok(this.pedidoService.listarPedidosOrdenado());
     }
+
+    @PutMapping("/status-pagamento")
+    @Operation(summary = "Este endpoint atualiza o status do pagamento do pedido.")
+    public ResponseEntity<PedidoDTO> atualizaStatusPagamentoPedido(@Valid @RequestBody PedidoStatusPagamentoDTO pedidoStatusPagamentoDTO) {
+        return ResponseEntity.ok(this.pedidoService.atualizarStatusPagamento(pedidoStatusPagamentoDTO));
+    }
+
 
 
 }

--- a/src/main/resources/db/migration/V1.1.4__alter_table_pedido_status_pedido.sql
+++ b/src/main/resources/db/migration/V1.1.4__alter_table_pedido_status_pedido.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public.pedido ADD status_pagamento int2 NULL;
+
+ALTER TABLE public.pedido ADD CONSTRAINT pedido_status_pagamento_check CHECK (((status_pagamento >= 0) AND (status_pagamento <= 3)));


### PR DESCRIPTION
Introduced a new `statusPagamento` field in the `Pedido` entity to track payment status. Implemented necessary changes including database schema update, new DTO, use case, and service method to handle payment status updates. Added a new endpoint in `PedidoController` for updating the payment status of a `Pedido`.